### PR TITLE
C++11-ification of ArrayList and other fixes to make the generated C++ code compile.

### DIFF
--- a/ProtoZBuffer/Generators/CppGenerator.cs
+++ b/ProtoZBuffer/Generators/CppGenerator.cs
@@ -538,7 +538,7 @@ namespace protozbuffer.Generators
             {0}->setFieldId({5});
             {0}->setIndex(index);
             {0}->setParent(this);
-            m_{0}List.set(index, {0});
+            m_{0}List.set(index, std::move({0}));
             return *m_{0}List.get(index);
         }}
 
@@ -556,13 +556,13 @@ namespace protozbuffer.Generators
 
         {3}& Abstract{4}::get{1}(int index)
         {{
-            if (m_{0}List.get(index) == nullptr)
+            if (!m_{0}List.get(index))
             {{
                 auto {0} = {3}::ParseFrom(contentStream(), m_header.{2}(index));
                 {0}->setFieldId({5});
                 {0}->setIndex(index);
                 {0}->setParent(this);
-                m_{0}List.set(index, {0});
+                m_{0}List.set(index, std::move({0}));
             }}
             return *m_{0}List.get(index);
         }}
@@ -1240,26 +1240,37 @@ GetNamespaceEnd(Namespace));            // 5
             {
                 strm.WriteLine(
 @"#include <stdafx.h>
-#include ""include/{0}/{1}.h""
+#include ""include/{0}/{1}.h"""
+, GetNamespacePathSlash(Namespace),  // 0
+message.name.Capitalize()            // 1
+);
+                foreach (var field in message.field.Where(_ => _.type == typeType.nestedMessage))
+                {
+                strm.WriteLine(
+@"#include ""include/{0}/{1}.h"""
+, GetNamespacePathSlash(Namespace),  // 0
+field.messageType.Capitalize()       // 1
+);
+                }
+
+                strm.WriteLine(
+@"{1}
+
+    {0}::{0}()
+    {{
+        // NOP
+    }}
+
+    {0}::{0}(const generated::{0}Header& header, int posInContent) : Abstract{0}(header, posInContent)
+    {{
+        // NOP
+    }}
 
 {2}
-
-    {1}::{1}()
-    {{
-        // NOP
-    }}
-
-    {1}::{1}(const generated::{1}Header& header, int posInContent) : Abstract{1}(header, posInContent)
-    {{
-        // NOP
-    }}
-
-{3}
 "
-, GetNamespacePathSlash(Namespace), // 0
-message.name.Capitalize(),              // 1
-GetNamespaceBegin(Namespace),           // 2
-GetNamespaceEnd(Namespace));            // 3);
+, message.name.Capitalize(),            // 0
+GetNamespaceBegin(Namespace),           // 1
+GetNamespaceEnd(Namespace));            // 2);
             }
         }
 

--- a/ProtoZBuffer/res/cpp/ArrayList.h
+++ b/ProtoZBuffer/res/cpp/ArrayList.h
@@ -3,26 +3,22 @@
 
 %NAMESPACE_BEGIN%
 
-template <class T> class ArrayList
+template <class T>
+class ArrayList
 {
-private:
-
-    std::vector<T*> m_map;
-    typedef typename std::vector<T*>::iterator iterator;
-
 public:
 
     T* get(std::size_t index)
     {
-        return index < size() ? m_map.at(index) : nullptr;
+        return index < size() ? m_map[index].get() : nullptr;
     }
 
-    void set(std::size_t index, std::unique_ptr<T>& value)
+    void set(std::size_t index, std::unique_ptr<T>&& value)
     {
-        // pad with nullptrs until m_map.size() >= index + 1 
+        // pad with nullptrs so that m_map.size() >= index + 1 
         if (index >= m_map.size())
-            m_map.insert(m_map.end(), index + 1 - m_map.size(), nullptr);
-        m_map[index] = value.release(); // takes ownership
+            m_map.resize(index + 1 - m_map.size());
+        m_map[index] = std::move(value);
     }
 
     std::size_t size() const
@@ -32,16 +28,11 @@ public:
 
     void clear()
     {
-        for (auto item : m_map)
-        {
-            delete item;
-        }
-
         m_map.clear();
     }
 
-    ~ArrayList() { clear(); }
-
+private:
+    std::vector<std::unique_ptr<T>> m_map;
 };
 
 %NAMESPACE_END%


### PR DESCRIPTION
(1) C++(11)-ification of ArrayList
(2) Compilation of generated code was broken due to deletion
    of incomplete type, need to have the cpp file include
    the headers for "nested messages" too.
