### PR TITLE
Fix generated C++ code, 'auto * tmp_{0} = ...' needs a pointer on the…

### DIFF
--- a/ProtoZBuffer/Generators/CppGenerator.cs
+++ b/ProtoZBuffer/Generators/CppGenerator.cs
@@ -967,7 +967,7 @@ namespace protozbuffer.Generators
                 {
                     CppWriter.WriteLine(
 @"
-            auto* tmp_{0} = {0}();
+            auto* tmp_{0} = m_{0}.get();
             if (tmp_{0} != nullptr) 
             {{ 
                 auto oldPos = tmp_{0}->positionInContent();


### PR DESCRIPTION
… right side of '='.
