### PR TITLE
adding option to generate a C++ version with dllexport/import

### DIFF
--- a/ProtoZBuffer.Console/CommandLineExecuter.cs
+++ b/ProtoZBuffer.Console/CommandLineExecuter.cs
@@ -57,7 +57,8 @@ namespace ProtoZBuffer.Console
                 Namespace = option.Namespace,
                 OutputFolder = option.Folder,
                 ProtoZFile = option.File,
-                ProtoGenFolder = option.ProtobufPath
+                ProtoGenFolder = option.ProtobufPath,
+                CppDll = option.CppDll
             };
 
             return generator.Launch();

--- a/ProtoZBuffer.Console/Options.cs
+++ b/ProtoZBuffer.Console/Options.cs
@@ -58,6 +58,9 @@ namespace ProtoZBuffer.Console
             Required = false)]
         public string ProtobufPath { get; set; }
 
+        [Option('d', "dll", Required=false, DefaultValue=false, HelpText="For C++, generate code with dllexport/dllimport switch")]
+        public bool CppDll { get; set; }
+
         public abstract bool Accept(IOptionVisitor visitor);
     }
 

--- a/ProtoZBuffer.Core/Generators/AbstractGenerator.cs
+++ b/ProtoZBuffer.Core/Generators/AbstractGenerator.cs
@@ -29,6 +29,9 @@ namespace ProtoZBuffer.Core.Generators
         ///<summary>Path to the input protoz file</summary> 
         public string ProtoZFile { get; set; }
 
+        ///<summary>Do we generate dllexport for c++</summary> 
+        public bool CppDll { get; set; }
+
         protected string ProtocBinary
         {
             get

--- a/ProtoZBuffer.Core/Generators/CppGenerator.cs
+++ b/ProtoZBuffer.Core/Generators/CppGenerator.cs
@@ -123,6 +123,19 @@ namespace ProtoZBuffer.Core.Generators
 #include ""{1}.pb.h""
 #include ""{0}/ArrayList.h""
 ", GetNamespacePathSlash(ResourceNamespace), DocumentName);
+            
+            if (CppDll)
+            {
+                IncludeWriter.WriteLine(@"
+
+#ifdef CASTIL_EXPORTS
+#define CASTIL_API __declspec(dllexport)
+#else
+#define CASTIL_API __declspec(dllimport)
+#endif
+             
+");
+            }
 
             // forward declaration for final client classes
             IncludeWriter.WriteLine(GetNamespaceBegin(Namespace));
@@ -274,10 +287,16 @@ namespace ProtoZBuffer.Core.Generators
 
         protected override void InitializeAbstractClass(messageType message)
         {
+            string export = "";
+            if (CppDll)
+            {
+                export = "CASTIL_API ";
+            }
+
             IncludeWriter.WriteLine(
-@"    class Abstract{0} : public ProtoOrBuilder
+@"    class {0}Abstract{1} : public ProtoOrBuilder
     {{"
-                , message.name);
+                , export, message.name);
         }
 
         protected override void EndAbstractClass(messageType message)


### PR DESCRIPTION
a new option -d or --dll
when used on C++ it will modify the generated .lazy.h

by declaring
`
#ifdef CASTIL_EXPORTS
#define CASTIL_API __declspec(dllexport)
#else
#define CASTIL_API __declspec(dllimport)
#endif
`


and all defined classes as exported in the sense of dllexport/dllimport

`
...
class CASTIL_API AbstractXXX 
{
`
